### PR TITLE
Fix backward incompatible change

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -14,6 +14,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.4.2" date="2016-08-17" min="2.6.0" max="2.x.x">
+			- Supported on PHP 7
+			- Fix backward incompatible changes (New objects cannot be assigned by reference)
+		</release>		
 		<release version="1.4.1" date="2016-03-16" min="2.6.0" max="2.x.x">
 			- Updated compatibility info
 			- Fix errors on field creation

--- a/fields/field.xml.php
+++ b/fields/field.xml.php
@@ -34,7 +34,7 @@ class FieldXML extends fieldTextarea
         }
 
         include_once(TOOLKIT . '/class.xsltprocess.php');
-        $xsltProc =& new XsltProcess;
+        $xsltProc = new XsltProcess;
 
         if (!General::validateXML($data, $errors, false, $xsltProc)) {
 


### PR DESCRIPTION
Supported on PHP 7.
- Fix new objects cannot be assigned by reference.
- New release.
